### PR TITLE
Depend on Nokogiri 1.6 instead of 1.5

### DIFF
--- a/hyp_diff.gemspec
+++ b/hyp_diff.gemspec
@@ -20,7 +20,7 @@ HypDiff compares HTML snippets. It generates a diff between two input snippets. 
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.5.6"
+  spec.add_dependency "nokogiri", "~> 1.6.5"
   spec.add_dependency "diff-lcs", "~> 1.2.5"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Fixes #1

The current Rails version (4.2) indirectly depends on Nokogiri 1.6.
In order to make this lib available for application with the newest Rails version,
this lib needs to depend on Nokogiri 1.6.
